### PR TITLE
[Update build.sh] Introduce compile-time dependency checks to build script

### DIFF
--- a/compile/build.sh
+++ b/compile/build.sh
@@ -1,5 +1,33 @@
 #!/bin/bash
 
+
+# Begin with compile-time dependencies check
+
+required=("gcc" "grub-mkrescue" "nasm" "ld")
+missing=()
+
+for utility in "${required[@]}"; do
+    if ! command -v "$utility" &>/dev/null; then
+        missing+=("$utility")  # Add any missing utilities to the list
+    fi
+done
+
+# Print warn if anything is missing
+if [ ${#missing[@]} -gt 0 ]; then
+    missing_list=""
+    
+    for utility in "${missing[@]}"; do
+        if [ -n "$missing_list" ]; then
+            missing_list+=", "
+        fi
+        missing_list+="$utility"
+    done
+    
+    # Warn lines formatted with ANSI escape sequences
+    echo -e "\033[1mWARN: Following utilities are \033[31mmissing\033[0m: \033[1m$missing_list. Build may result in partial or total failure.\033[0m"
+    echo -e "\033[1mMake sure all build-time dependencies are installed and properly configured.\033[0m"
+fi
+
 set -e
 
 ROOT_DIR=$(pwd)
@@ -40,4 +68,4 @@ EOF
 
 grub-mkrescue -o "$ISO_OUTPUT" "$ISO_DIR"
 
-echo "Success!"
+echo -e "\033[32mSuccess!\033[0m" # Success colored to green - let's be happy


### PR DESCRIPTION
Added bash logic that checks if all necessary programs are installed. If anything is missing, it prints a warning lines before continuing (They are formatted with ANSI sequences to bold them and make word 'missing' red - to be clearly visible and gain attention). 

Reason to implement such thing is that it if something misses and build.sh is run, it only mentions first command that's missing before exiting. With this dependency check, **all** missing utilities will be immediately listed at once. Thanks to it, users who have multiple missing dependencies won't have to experience installing dependencies one by one because their terminal only tells one thing at a time. 

(Yeah, I am aware that all dependencies are listed in CONTRIBUTING.md and can easily be accessed, but not all people are smart enough to look for help on github)

I believe this will be especially useful in future, when the OS will get more advanced/complicated and will perhaps require more tools to build - it'll be possible to add these tools to this check (I don't know the future, but I think it is better to act preventively).

also, the success echo line has been colored green.