### PR TITLE
Update panic.h - redesigned kernel panic, clearing registers for safety

### DIFF
--- a/kernel/include/panic.h
+++ b/kernel/include/panic.h
@@ -18,17 +18,34 @@
 #include <types.h>
 #include <screen.h>
 
-void kernelpanic(const char *errcode) {
+void kernelpanic(const char *paniccode) {
     paintscreen(COLOR_3);
     println(" ", COLOR_1);
     println(" Kernel panic!", COLOR_2);
     println(" ", COLOR_1);
-    print(" The system encountered a problem and could not continue! \n You can turn off the computer manually using the power button.", COLOR_1);
+    print(" AurorOS has encountered a critical problem and could not continue!", COLOR_1);
     println(" ", COLOR_1);
-    print(" Error code: ", COLOR_1);
-    print(errcode, COLOR_2);
+    print(" Kernel panic code: ", COLOR_1);
+    print(paniccode, COLOR_2);
+    println(" ", COLOR_1);
+    println(" ", COLOR_1);
+    print(" System halted and will not power off automatically. \n You can turn off your device manually by holding the power button.", COLOR_1);
+
+    // Zeroing General-Purpose registers for sake of security - all potentially sensitive stuff shall be removed
+    asm(
+        "xor %%eax, %%eax\n"
+        "xor %%ebx, %%ebx\n"
+        "xor %%ecx, %%ecx\n"
+        "xor %%edx, %%edx\n"
+        "xor %%esi, %%esi\n"
+        "xor %%edi, %%edi\n"
+        "xor %%ebp, %%ebp\n"
+        : 
+        : 
+        : "%eax", "%ebx", "%ecx", "%edx", "%esi", "%edi", "%ebp"
+    );
 
     while (true) {
-        asm("hlt");
+        asm("hlt\n");
     }
 }


### PR DESCRIPTION
Kernel panic screen lines have been rephrased.. a cosmetic change, basically.

What's more important, assembly logic to clear GP registers before halting has been implemented. Its purpose is to clear registers so even if there are some microarch vulnerabilities, data in registers cannot be accessed post-panic by malicious actors. Data might be sensitive, after all, so it's better to clean it than to cry about it being captured by some hostile individuals.